### PR TITLE
register svg plugin before babel

### DIFF
--- a/packages/pectin-core/lib/getPlugins.js
+++ b/packages/pectin-core/lib/getPlugins.js
@@ -25,11 +25,11 @@ module.exports = async function getPlugins(pkg) {
         }),
         // https://github.com/rollup/rollup-plugin-json#usage
         json(),
+        // https://github.com/antony/rollup-plugin-svg
+        svg(),
         // https://github.com/rollup/rollup-plugin-babel#configuring-babel
         babel(rc),
         // https://github.com/rollup/rollup-plugin-commonjs#usage
         commonjs(),
-        // https://github.com/antony/rollup-plugin-svg
-        svg(),
     ];
 };

--- a/packages/pectin-core/test/__snapshots__/pectin-core.test.js.snap
+++ b/packages/pectin-core/test/__snapshots__/pectin-core.test.js.snap
@@ -3,7 +3,7 @@
 exports[`pectin-core integration: cjs 1`] = `
 "'use strict';
 
-var svgTest = 'data:image/svg+xml;base64,dGVzdDs=';
+var svgTest = 'data:image/svg+xml;base64,dGVzdA==';
 
 function foo() {
   return svgTest;
@@ -14,7 +14,7 @@ module.exports = foo;
 `;
 
 exports[`pectin-core integration: esm 1`] = `
-"var svgTest = 'data:image/svg+xml;base64,dGVzdDs=';
+"var svgTest = 'data:image/svg+xml;base64,dGVzdA==';
 
 function foo() {
   return svgTest;

--- a/packages/pectin-core/test/pectin-core.test.js
+++ b/packages/pectin-core/test/pectin-core.test.js
@@ -58,9 +58,9 @@ describe('pectin-core', () => {
                 expect.objectContaining({ name: 'subpath-externals' }),
                 expect.objectContaining({ name: 'node-resolve' }),
                 expect.objectContaining({ name: 'json' }),
+                expect.objectContaining({ name: 'svg' }),
                 expect.objectContaining({ name: 'babel' }),
                 expect.objectContaining({ name: 'commonjs' }),
-                expect.objectContaining({ name: 'svg' }),
             ],
         });
     });


### PR DESCRIPTION
Turns out babel is picking up the svg file and transpiling it as JSX, moving the loader up fixes that and correctly encodes the file