### PR TITLE
feat(core): Enable code splitting for esm output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -343,6 +343,15 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0.tgz",
+      "integrity": "sha512-Gt9xNyRrCHCiyX/ZxDGOcBnlJl0I3IWicpZRC4CdC0P5a/I07Ya2OAMEBU+J7GmRFVmIetqEYRko6QYRuKOESw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-syntax-json-strings": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",
+    "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
     "babel-core": "^7.0.0-bridge.0",

--- a/packages/pectin-core/lib/pectin-core.js
+++ b/packages/pectin-core/lib/pectin-core.js
@@ -25,12 +25,18 @@ module.exports.loadManifest = loadManifest;
 
 async function createMultiConfig(pkg, { cwd }) {
     const input = getInput(pkg, cwd);
-    const outputs = getOutput(pkg, cwd);
+    const outputs = getOutput(pkg, cwd, true);
 
     return pMap(outputs, async output => {
         const plugins = await getPlugins(pkg, cwd, output);
 
-        // output array for consistency with createConfig()
-        return { input, output: [output], plugins };
+        return {
+            input,
+            // output array for consistency with createConfig()
+            output: [output],
+            plugins,
+            // TODO: remove when rollup 1.0 makes this the default
+            experimentalCodeSplitting: output.format === 'esm',
+        };
     });
 }


### PR DESCRIPTION
Whenever `esm` output is enabled (adding a `"module"` field to package.json), it will now automatically code split. The `cjs` output will inline the dynamic import wrapped in a Promise, so no extra Babel config is necessary.

Fixes #5