### PR TITLE
feat: Support typescript extensions

### DIFF
--- a/packages/pectin-babelrc/lib/pectin-babelrc.js
+++ b/packages/pectin-babelrc/lib/pectin-babelrc.js
@@ -108,6 +108,7 @@ module.exports = async function pectinBabelrc(pkg, cwd, output) {
     // rollup-specific babel config
     rc.babelrc = false;
     rc.exclude = 'node_modules/**';
+    rc.extensions = ['.js', '.jsx', '.es6', '.es', '.mjs', '.ts', '.tsx'];
 
     return rc;
 };

--- a/packages/pectin-babelrc/test/pectin-babelrc.test.js
+++ b/packages/pectin-babelrc/test/pectin-babelrc.test.js
@@ -46,14 +46,23 @@ describe('pectin-babelrc', () => {
         const rc = await pectinBabelrc(pkg, cwd);
 
         expect(rc).toMatchInlineSnapshot(`
-Object {
-  "babelrc": false,
-  "exclude": "node_modules/**",
-  "presets": Array [
-    "@babel/env",
-  ],
-}
-`);
+            Object {
+              "babelrc": false,
+              "exclude": "node_modules/**",
+              "extensions": Array [
+                ".js",
+                ".jsx",
+                ".es6",
+                ".es",
+                ".mjs",
+                ".ts",
+                ".tsx",
+              ],
+              "presets": Array [
+                "@babel/env",
+              ],
+            }
+        `);
     });
 
     it('enables runtimeHelpers when @babel/runtime is a dependency', async () => {
@@ -116,14 +125,23 @@ Object {
         const rc = await pectinBabelrc(pkg, cwd);
 
         expect(rc).toMatchInlineSnapshot(`
-Object {
-  "babelrc": false,
-  "exclude": "node_modules/**",
-  "presets": Array [
-    "@babel/preset-env",
-  ],
-}
-`);
+            Object {
+              "babelrc": false,
+              "exclude": "node_modules/**",
+              "extensions": Array [
+                ".js",
+                ".jsx",
+                ".es6",
+                ".es",
+                ".mjs",
+                ".ts",
+                ".tsx",
+              ],
+              "presets": Array [
+                "@babel/preset-env",
+              ],
+            }
+        `);
     });
 
     it('finds .babelrc.js config', async () => {
@@ -141,14 +159,23 @@ Object {
         const rc = await pectinBabelrc(pkg, cwd);
 
         expect(rc).toMatchInlineSnapshot(`
-Object {
-  "babelrc": false,
-  "exclude": "node_modules/**",
-  "presets": Array [
-    "@babel/preset-env",
-  ],
-}
-`);
+            Object {
+              "babelrc": false,
+              "exclude": "node_modules/**",
+              "extensions": Array [
+                ".js",
+                ".jsx",
+                ".es6",
+                ".es",
+                ".mjs",
+                ".ts",
+                ".tsx",
+              ],
+              "presets": Array [
+                "@babel/preset-env",
+              ],
+            }
+        `);
     });
 
     it('finds pkg.babel config', async () => {
@@ -164,14 +191,23 @@ Object {
         const rc = await pectinBabelrc(pkg, cwd);
 
         expect(rc).toMatchInlineSnapshot(`
-Object {
-  "babelrc": false,
-  "exclude": "node_modules/**",
-  "presets": Array [
-    "@babel/preset-env",
-  ],
-}
-`);
+            Object {
+              "babelrc": false,
+              "exclude": "node_modules/**",
+              "extensions": Array [
+                ".js",
+                ".jsx",
+                ".es6",
+                ".es",
+                ".mjs",
+                ".ts",
+                ".tsx",
+              ],
+              "presets": Array [
+                "@babel/preset-env",
+              ],
+            }
+        `);
     });
 
     it('does not duplicate simple runtime transform', async () => {
@@ -452,66 +488,102 @@ Object {
         ]);
 
         expect(config1).toMatchInlineSnapshot(`
-Object {
-  "babelrc": false,
-  "exclude": "node_modules/**",
-  "plugins": Array [
-    "@babel/plugin-proposal-object-rest-spread",
-  ],
-  "presets": Array [
-    "@babel/preset-env",
-  ],
-}
-`);
+            Object {
+              "babelrc": false,
+              "exclude": "node_modules/**",
+              "extensions": Array [
+                ".js",
+                ".jsx",
+                ".es6",
+                ".es",
+                ".mjs",
+                ".ts",
+                ".tsx",
+              ],
+              "plugins": Array [
+                "@babel/plugin-proposal-object-rest-spread",
+              ],
+              "presets": Array [
+                "@babel/preset-env",
+              ],
+            }
+        `);
         expect(config2).toMatchInlineSnapshot(`
-Object {
-  "babelrc": false,
-  "exclude": "node_modules/**",
-  "plugins": Array [
-    "lodash",
-  ],
-  "presets": Array [
-    "@babel/env",
-  ],
-}
-`);
+            Object {
+              "babelrc": false,
+              "exclude": "node_modules/**",
+              "extensions": Array [
+                ".js",
+                ".jsx",
+                ".es6",
+                ".es",
+                ".mjs",
+                ".ts",
+                ".tsx",
+              ],
+              "plugins": Array [
+                "lodash",
+              ],
+              "presets": Array [
+                "@babel/env",
+              ],
+            }
+        `);
         expect(config3).toMatchInlineSnapshot(`
-Object {
-  "babelrc": false,
-  "exclude": "node_modules/**",
-  "plugins": Array [
-    Array [
-      "@babel/plugin-transform-runtime",
-      Object {
-        "useESModules": false,
-      },
-    ],
-  ],
-  "presets": Array [
-    "@babel/preset-env",
-  ],
-  "runtimeHelpers": true,
-}
-`);
+            Object {
+              "babelrc": false,
+              "exclude": "node_modules/**",
+              "extensions": Array [
+                ".js",
+                ".jsx",
+                ".es6",
+                ".es",
+                ".mjs",
+                ".ts",
+                ".tsx",
+              ],
+              "plugins": Array [
+                Array [
+                  "@babel/plugin-transform-runtime",
+                  Object {
+                    "useESModules": false,
+                  },
+                ],
+              ],
+              "presets": Array [
+                "@babel/preset-env",
+              ],
+              "runtimeHelpers": true,
+            }
+        `);
         expect(config4).toMatchInlineSnapshot(`
-Object {
-  "babelrc": false,
-  "exclude": "node_modules/**",
-  "plugins": Array [
-    "@babel/plugin-syntax-dynamic-import",
-    "@babel/plugin-proposal-object-rest-spread",
-    Array [
-      "@babel/plugin-transform-runtime",
-      Object {
-        "useESModules": true,
-      },
-    ],
-  ],
-  "presets": Array [
-    "@babel/preset-env",
-  ],
-  "runtimeHelpers": true,
-}
-`);
+            Object {
+              "babelrc": false,
+              "exclude": "node_modules/**",
+              "extensions": Array [
+                ".js",
+                ".jsx",
+                ".es6",
+                ".es",
+                ".mjs",
+                ".ts",
+                ".tsx",
+              ],
+              "plugins": Array [
+                "@babel/plugin-syntax-dynamic-import",
+                "@babel/plugin-proposal-object-rest-spread",
+                Array [
+                  "@babel/plugin-transform-runtime",
+                  Object {
+                    "useESModules": true,
+                  },
+                ],
+              ],
+              "presets": Array [
+                "@babel/preset-env",
+              ],
+              "runtimeHelpers": true,
+            }
+        `);
     });
 });

--- a/packages/pectin-core/lib/getPlugins.js
+++ b/packages/pectin-core/lib/getPlugins.js
@@ -25,7 +25,7 @@ module.exports = async function getPlugins(pkg, cwd, output) {
         nodeResolve({
             preferBuiltins: true,
             // https://github.com/rollup/rollup-plugin-node-resolve/pull/151
-            extensions: ['.mjs', '.js', '.jsx', '.json', '.node'],
+            extensions: ['.mjs', '.js', '.jsx', '.json', '.node', '.ts', '.tsx'],
             // https://github.com/rollup/rollup-plugin-node-resolve/pull/182
             mainFields: [
                 'module',


### PR DESCRIPTION
Great solution, both lerna & pectin are making life easier 🙏🏻

i used pectin in a monorepo that is using typescript, and it was necessary to support `.ts`, `.tsx` extensions to make it work.

