### PR TITLE
fix(isUpToDate): add `ts` and `tsx` to isUpToDate matchers

### DIFF
--- a/packages/pectin-api/lib/pectin-api.js
+++ b/packages/pectin-api/lib/pectin-api.js
@@ -107,7 +107,7 @@ async function isUpToDate(opts, config) {
 
     const matchers = [
         // include all .js and .jsx files
-        '**/*.@(js|jsx)',
+        '**/*.@(js|jsx|ts|tsx)',
         // except *.test.js and *-test.js
         '!**/*@(.|-)test.js',
         // ignoring anything under __tests__


### PR DESCRIPTION
This should have been done along with https://github.com/evocateur/pectin/pull/8